### PR TITLE
fix Version.comparator_reduce and add a QCheck based test

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,3 +1,3 @@
 S src/
 B _build/src/
-PKG oasis unix str
+PKG oasis unix str qcheck qcheck.ounit oUnit

--- a/_oasis
+++ b/_oasis
@@ -23,6 +23,17 @@ Executable oasis2opam
   BuildTools:     ocamlbuild
   Install:        true
 
+Executable version_test
+  Build$: flag(tests)
+  Path: src/
+  MainIs: version_test.ml
+  BuildDepends:   oasis (>= 0.4.4), oasis.builtin-plugins, unix, str, qcheck (>= 0.4), qcheck.ounit, oUnit (>= 2.0.0)
+  CompiledObject: best
+  BuildTools:     ocamlbuild
+  Install:        false
+
+Test version
+  Command: $version_test
 
 SourceRepository master
   Type:     git

--- a/src/version_test.ml
+++ b/src/version_test.ml
@@ -1,0 +1,40 @@
+open OUnit2
+open QCheck
+open OASISVersion
+
+let version_of_int i = OASISVersion.version_of_string (string_of_int i)
+let arbitrary_version = Arbitrary.(small_int >|= version_of_int)
+
+let arbitrary_version_comparator =
+  Arbitrary.(retry (
+    small_int >>= fix_fuel [
+      `Base (arbitrary_version >>= fun v ->
+             among [VGreater v; VGreaterEqual v; VEqual v; VLesser v; VLesserEqual v]);
+      `Rec (fun self ->
+          self 2 >>= function
+          | [x;y] -> among [VOr (x,y); VAnd (x,y)]
+          | _ -> assert false
+        )]))
+
+let rec  comparator_size = function
+  | VGreater _ | VGreaterEqual _ | VEqual _ | VLesser _ | VLesserEqual _ -> 1
+  | VOr (a, b) | VAnd (a, b) -> comparator_size a + comparator_size b
+
+let equivalent ~pp ~name ~size gen f is_equivalent =
+  let pp (v1, v2) =
+    Printf.sprintf "\n(%s)\n!=\n(%s)" (pp v1) (pp v2) in
+  let size (v, _) = size v in
+  mk_test ~n:1000 ~pp ~name ~size Arbitrary.(gen >|= fun v -> v, f v) is_equivalent
+
+let is_equivalent (a, b) =
+  (a = b) ||
+  match check arbitrary_version (fun v -> OASISVersion.comparator_apply v a = OASISVersion.comparator_apply v b) with
+  | Ok _ -> true
+  | Failed _ | Error _ -> false
+
+let suite = QCheck_ounit.to_ounit_suite [
+    equivalent ~pp:Version.string_of_comparator ~name:"comparator_reduce" ~size:comparator_size arbitrary_version_comparator
+      Version.comparator_reduce is_equivalent
+  ]
+
+let () = OUnit2.run_test_tt_main ("version" >::: suite)


### PR DESCRIPTION
`Version.comparator_reduce` didn't handle `or` properly (got turned into `and` or assertion was failing).

The QCheck test generates random instances of version comparators, runs it through `comparator_reduce` and tests for equivalenece (by generating random instances of versions and evaluating them).