### PR TITLE
dash: convert underscores to dashes in flag names

### DIFF
--- a/src/BuildDepends.ml
+++ b/src/BuildDepends.ml
@@ -526,12 +526,12 @@ let output t fmt flags =
   let opt_pkgs = constrain_opam_packages opt_pkgs in
   if opt_pkgs <> [] then (
     Format.fprintf fmt "@[<2>depopts: [";
-    List.iter (fun p -> match strings_of_packages p with
-                      | [] -> ()
-                      | p0 :: tl ->
-                         Format.fprintf fmt "@\n%s" p0;
-                         List.iter (fun s -> Format.fprintf fmt "@;<1 2>%s" s) tl;
-              ) opt_pkgs;
+    (* Optional dependencies do not allow version constraints. *)
+    List.iter (function
+                | (p0, _) :: tl ->
+                   Format.fprintf fmt "@\n%s" p0;
+                   assert(List.for_all (fun (p,_) -> p = p0) tl)
+                | [] -> ()) opt_pkgs;
     Format.fprintf fmt "@]@\n]@\n";
   );
   let opt_conflicts =

--- a/src/oasis2opam.ml
+++ b/src/oasis2opam.ml
@@ -131,6 +131,8 @@ let opam_for_flags flags =
        (n, pkgs) :: l in
   M.fold add_findlib flags []
 
+let underscore_re = Str.regexp "_"
+
 let output_build_install t fmt flags opam_file_version ~remove_with_oasis =
   let pkg = Tarball.oasis t in
   Format.fprintf fmt "@[<2>build: [@\n";
@@ -141,6 +143,7 @@ let output_build_install t fmt flags opam_file_version ~remove_with_oasis =
   Format.fprintf fmt "@[<2>[\"ocaml\" \"setup.ml\" \"-configure\" \
                       \"--prefix\" prefix";
   let flag_enable (flag, pkgs) =
+    let flag = Str.global_replace underscore_re "-" flag in
     match pkgs with
     | [] -> ()
     | [p] -> Format.fprintf fmt "@\n\"--%%{%s:enable}%%-%s\"" p flag


### PR DESCRIPTION
This pull request fixes a bug in oasis2opam related to package names and corresponding flags that contain underscores (`_`). Including a flag with underscores in an `_oasis` file like this:

```
Flag js_of_ocaml
  Description: build the Javascript dispatch library
  Default$: false
```
... will generate flags in the generated configure script that look like this:
```
  --enable-js-of-ocaml   build the Javascript dispatch library [default: disabled]
  --disable-js-of-ocaml  build the Javascript dispatch library [default: disabled]
```
The underscores in the flag&dmash;which corresponds with a valid package name&mdash;are converted by oasis to dashes. 